### PR TITLE
Add support for 'options' attribute

### DIFF
--- a/ng-epoch.js
+++ b/ng-epoch.js
@@ -51,6 +51,14 @@
     $scope.me;
     $scope.filterOptions = function () {
       var results = {};
+
+      // copy options first
+      if ($scope.options) {
+        angular.forEach($scope.options, function (v,k) {
+          this[k] = v;
+        }, results)
+      }
+      
       angular.forEach($scope, function (v, k) {
         if ( (k.indexOf('chart') === 0 || k.indexOf('gauge') === 0) &&
              (k !== 'chartClass' && k !== 'gaugeDialSize') ) {


### PR DESCRIPTION
Although being declared, the 'options' attribute was being ignored in
each of the directives, which prevented a user from providing any custom
options to a chart (like a custom domain option for a gauge). This
change adds the support for handling such a use-case.