### PR TITLE
Watch chartData

### DIFF
--- a/ng-epoch.js
+++ b/ng-epoch.js
@@ -82,6 +82,9 @@
     $scope.$watch('gaugeStream', function (newVal) {
       if (newVal) { $scope.me.update($scope.gaugeStream); }
     }, true);
+    $scope.$watch('chartData', function(newVal, oldVal) {
+      if (newVal != oldVal) { $scope.me.setData(newVal); }
+    }, true);
   });
 
   ngEpoch.directive('epochArea', function ($compile) {


### PR DESCRIPTION
Users should be able to change historical data if they need to. Here is my use case:

I was using this library and I needed to make a web API request to get historical data after "epochController" is initialized. However, I was not able to change the historical data after I got the historical data from the API call because "chartData" was not being watched. I added this watcher so that when users change "chartData", the graph will reflect the change.