### PR TITLE
handle updating data in static charts correctly

### DIFF
--- a/ng-epoch.js
+++ b/ng-epoch.js
@@ -83,7 +83,7 @@
       if (newVal) { $scope.me.update($scope.gaugeStream); }
     }, true);
     $scope.$watch('chartData', function(newVal, oldVal) {
-      if (newVal != oldVal) { $scope.me.setData(newVal); }
+      if (newVal != oldVal) { $scope.me.update(newVal); }
     }, true);
   });
 
@@ -92,8 +92,7 @@
       if (scope.chartClass) { elem.addClass(scope.chartClass); }
       var options = scope.filterOptions();
       options.type = 'area';
-      elem.epoch(options);
-      $compile(elem)(scope);
+      var area = scope.renderEpoch(elem, options);
     };
     return angular.extend(angular.copy(baseDirective), {link: areaFunction});
   });
@@ -113,8 +112,7 @@
       if (scope.chartClass) { elem.addClass(scope.chartClass); }
       var options = scope.filterOptions();
       options.type = 'bar';
-      elem.epoch(options);
-      $compile(elem)(scope);
+      var bar = scope.renderEpoch(elem, options);
     };
     return angular.extend(angular.copy(baseDirective), {link: barFunction});
   });
@@ -134,8 +132,7 @@
       if (scope.chartClass) { elem.addClass(scope.chartClass); }
       var options = scope.filterOptions();
       options.type = 'line';
-      elem.epoch(options);
-      $compile(elem)(scope);
+      var line = scope.renderEpoch(elem, options);
     };
     return angular.extend(angular.copy(baseDirective), {link: lineFunction});
   });
@@ -155,8 +152,7 @@
       if (scope.chartClass) { elem.addClass(scope.chartClass); }
       var options = scope.filterOptions();
       options.type = 'pie';
-      elem.epoch(options);
-      $compile(elem)(scope);
+      var pie = scope.renderEpoch(elem, options);
     };
     return angular.extend(angular.copy(baseDirective), {link: pieFunction});
   });
@@ -166,8 +162,7 @@
       if (scope.chartClass) { elem.addClass(scope.chartClass); }
       var options = scope.filterOptions();
       options.type = 'scatter';
-      elem.epoch(options);
-      $compile(elem)(scope);
+      var scatter = scope.renderEpoch(elem, options);
     };
     return angular.extend(angular.copy(baseDirective), {link: linkFunction});
   });


### PR DESCRIPTION
Currently updating data in static charts is broken.  The angular $watch method call `$scope.me.setData()` which firstly should be `setData()` and secondly is called on `$scope.me` which is not set in the static graph controllers.
